### PR TITLE
Added client method to request authorization with custom scope

### DIFF
--- a/Classes/FRDStravaClient+Access.h
+++ b/Classes/FRDStravaClient+Access.h
@@ -37,6 +37,15 @@ After the user successfuly authorized your app, Safari will open your app by lau
 -(void) authorizeWithCallbackURL:(NSURL *)callbackUrl stateInfo:(NSString *)stateInfo;
 
 /**
+ Initiate a OAUTH authorization with Strava. This method allows to specify a custom authorization scope.
+ 
+ @param callbackUrl The URL that will be called from Safari upon successful Authentication with the strava OAuth authorization web page. Typically you want your app to be launched back, so it should consist of a URL with a scheme you registered e.g. myAppRegisteredURLScheme://mydomain.com.
+ @param stateInfo (optional) a NSString that will be passed back in the callback URL, as a state attribute (...&state=blah).
+ @param scope (optional) a NSString that specifies the requested authorization scope ad comma delimited string of ‘view_private’ and/or ‘write’, leave blank for read-only permissions.
+ */
+-(void) authorizeWithCallbackURL:(NSURL *)callbackUrl stateInfo:(NSString *)stateInfo scope:(NSString *)scope;
+
+/**
  Method used in step #2 of the OAuth flow. See authorizeWithCallbackURL:stateInfo for detailed description.
  This method will parse the callback URL your app was launched with from Safari OAuth authentication page,
  and extract the authentication code you must use in step #3: exchangeTokenForCode:success:failure:.

--- a/Classes/FRDStravaClient+Access.m
+++ b/Classes/FRDStravaClient+Access.m
@@ -12,14 +12,21 @@
 
 -(void) authorizeWithCallbackURL:(NSURL *)callbackUrl stateInfo:(NSString *)stateInfo
 {
+    [self authorizeWithCallbackURL:callbackUrl stateInfo:stateInfo scope:@"write"];
+}
+
+-(void) authorizeWithCallbackURL:(NSURL *)callbackUrl stateInfo:(NSString *)stateInfo scope:(NSString *)scope {
     NSAssert(self.clientId != 0, @"clientID is 0, did you call initializeWithClientId:clientSecred: ?");
     NSAssert(self.clientSecret.length != 0, @"clientSecret is empty, did you call initializeWithClientId:clientSecred: ?");
     
     if (stateInfo == nil) {
         stateInfo = @"";
     }
+    if (scope == nil) {
+        scope = @"";
+    }
     
-    NSString *urlStr = [NSString stringWithFormat:@"https://www.strava.com/oauth/authorize?client_id=%ld&response_type=code&redirect_uri=%@&scope=write&state=%@&approval_prompt=force", (long)self.clientId, [callbackUrl absoluteString], [stateInfo stringByAddingPercentEscapesUsingEncoding:NSASCIIStringEncoding]];
+    NSString *urlStr = [NSString stringWithFormat:@"https://www.strava.com/oauth/authorize?client_id=%ld&response_type=code&redirect_uri=%@&scope=%@&state=%@&approval_prompt=force", (long)self.clientId, [callbackUrl absoluteString], scope, [stateInfo stringByAddingPercentEscapesUsingEncoding:NSASCIIStringEncoding]];
                                                                                                                                                                                                                                              
     
     NSURL *url = [NSURL URLWithString:urlStr];


### PR DESCRIPTION
In order to allow authorization with 'view_private' scope the scope should be able to be specified. If no scope is specified with the new method the users request view only authorization. The old method still authorizes the 'write' scope.
